### PR TITLE
Make change only to JS version of a CS lesson

### DIFF
--- a/.github/workflows/edits_to_duplicated_lessons.yml
+++ b/.github/workflows/edits_to_duplicated_lessons.yml
@@ -1,0 +1,57 @@
+name: Auto Comment
+on:
+  pull_request:
+    # types:
+    #   - opened
+    paths:
+      - "**/computer_science/**"
+
+jobs:
+  cs-auto-comment:
+    name: Remind about duplicated CS lessons
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get changed CS files
+        uses: tj-actions/changed-files@v46
+        id: changed-files
+        with:
+          files: |
+            **/computer_science/**
+          separator: " "
+
+      - name: Check for unduplicated changes
+        id: change-duplication
+        env:
+          CHANGED_CS_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          changed_cs_files=($CHANGED_CS_FILES)
+          changed_js_count=0
+          changed_ruby_count=0
+
+          for filepath in "${changed_cs_files[@]}"; do
+              if [[ $filepath == *javascript/* ]]; then
+                  ((changed_js_count++))
+              elif [[ $filepath == *ruby/* ]]; then
+                  ((changed_ruby_count++))
+              fi
+          done
+
+          (($changed_js_count == $changed_ruby_count)) && all_duplicated=true || all_duplicated=false
+          echo "all_duplicated=${all_duplicated}" >> $GITHUB_OUTPUT
+
+      - name: Comment if unduplicated changes
+        if: steps.change-duplication.outputs.all_duplicated == 'false'
+        run: |
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          REPO=${{ github.repository }}
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMENT="Each pathway has its own computer science lesson files and it looks like you've only made changes to one pathway's lessons. Check if the changes are only needed for that pathway, otherwise please make the equivalent changes to the other pathway's lessons as well."
+
+          curl -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            -d "{\"body\":\"${COMMENT}\"}"
+

--- a/javascript/computer_science/project_recursion.md
+++ b/javascript/computer_science/project_recursion.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Use what you have learnt about recursion so far to tackle two classic problems that can leverage recursion: Fibonacci and Merge Sort.
+Use what you have learnt about recursion so far to tackle two classic problems that can leverage recursion: Fibonacci and Merge Sort. A change to the JS version!
 
 #### Fibonacci
 


### PR DESCRIPTION
1. GHA should auto-comment because change not duplicated in Ruby version of lesson
2. GHA should only comment on PR opening, not new commits